### PR TITLE
update meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,13 +11,14 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation
+  number: 1
 
 requirements:
   host:
     - pip
     - python >=3.6
+    - setuptools-scm
   run:
     - packaging
     - python >=3.6


### PR DESCRIPTION
This PR adds `setuptools-scm` so the version is maintained when it is used as a dependency. This is required because the `fancylog` build was moved to dynamic versioning after it was added to conda.

I also added the `--no-build-isolation` to the pip build which I think grayskull now reccomends and means pip doesn't re-install all the conda-installed deps.

Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ]**(NA)** Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.
